### PR TITLE
Prefix service tag for command_bus with broadway

### DIFF
--- a/src/BroadwayBundle.php
+++ b/src/BroadwayBundle.php
@@ -44,7 +44,7 @@ class BroadwayBundle extends Bundle
         $container->addCompilerPass(
             new RegisterBusSubscribersCompilerPass(
                 'broadway.command_handling.command_bus',
-                'command_handler',
+                'broadway.command_handler',
                 \Broadway\CommandHandling\CommandHandlerInterface::class
             )
         );


### PR DESCRIPTION
Prefix service tag for command_bus with broadway

For example, our project uses SimpleBus which already took over the `command_handler` tag. 
