### PR TITLE
fix saga default configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -87,6 +87,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('saga')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->enumNode('repository')
                             ->values(['in_memory', 'mongodb'])


### PR DESCRIPTION
Pull request #12 make error on default bundle configuration.

```
LogicException in RegisterSagaCompilerPass.php line 36:
Unknown saga manager service known as broadway.saga.multiple_saga_manager
```

I fixed that adding to my config.yml

```
broadway:
    saga: ~
```

This pull request fix configuration to works with default bundle configuration.