### PR TITLE
fix saga state repository compiler pass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     "symfony/proxy-manager-bridge": "~2.4",
     "phpunit/phpunit": "^4.8",
     "matthiasnoback/symfony-config-test": "^2.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^1.1"
+    "matthiasnoback/symfony-dependency-injection-test": "^1.1",
+    "broadway/broadway-saga": "^0.2"
   },
   "suggest": {
     "psr/log-implementation": "Implementation for PSR3, LoggerInterface",

--- a/src/DependencyInjection/RegisterSagaStateRepositoryCompilerPass.php
+++ b/src/DependencyInjection/RegisterSagaStateRepositoryCompilerPass.php
@@ -11,7 +11,7 @@
 
 namespace Broadway\Bundle\BroadwayBundle\DependencyInjection;
 
-use Broadway\EventStore\EventStore;
+use Broadway\Saga\State\RepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class RegisterSagaStateRepositoryCompilerPass extends CompilerPass
@@ -30,7 +30,7 @@ class RegisterSagaStateRepositoryCompilerPass extends CompilerPass
 
         $serviceId = $container->getParameter($serviceParameter);
 
-        $this->assertDefinitionImplementsInterface($container, $serviceId, EventStore::class);
+        $this->assertDefinitionImplementsInterface($container, $serviceId, RepositoryInterface::class);
 
         $container->setAlias(
             'broadway.saga.state.repository',

--- a/test/DependencyInjection/CompilerPass/RegisterSagaStateRepositoryCompilerPassTest.php
+++ b/test/DependencyInjection/CompilerPass/RegisterSagaStateRepositoryCompilerPassTest.php
@@ -12,6 +12,7 @@
 namespace Broadway\Bundle\BroadwayBundle\DependencyInjection;
 
 use Broadway\EventStore\EventStore;
+use Broadway\Saga\State\RepositoryInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -49,7 +50,7 @@ class RegisterSagaStateRepositoryCompilerPassTest extends AbstractCompilerPassTe
             'my_saga_state_repository'
         );
 
-        $this->setDefinition('my_saga_state_repository', new Definition(EventStore::class));
+        $this->setDefinition('my_saga_state_repository', new Definition(RepositoryInterface::class));
 
         $this->compile();
 
@@ -77,7 +78,7 @@ class RegisterSagaStateRepositoryCompilerPassTest extends AbstractCompilerPassTe
     /**
      * @test
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Service "stdClass" must implement interface "Broadway\EventStore\EventStore".
+     * @expectedExceptionMessage Service "stdClass" must implement interface "Broadway\Saga\State\RepositoryInterface".
      */
     public function it_throws_when_configured_saga_state_repository_does_not_implement_event_store_interface()
     {


### PR DESCRIPTION
The `RegisterSagaStateRepositoryCompilerPass` checks for the wrong interface, `Broadway\EventStore\EventStore` instead of `Broadway\Saga\State\RepositoryInterface`.

I had to `require --dev` the `broadway/broadway-saga` package in order to have access to the required interface because the interface is not part of the `broadway/broadway` package. 
This is just a quick fix to have green tests, I think it would be better to have the interface in the core package. But I don't know your plans with the sagas, so I didn't want to introduce this by myself.