### PR TITLE
added type:"symfony-bundle" to work with symfony-flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "broadway/broadway-bundle",
+  "type": "symfony-bundle",
   "description": "Symfony bundle for broadway/broadway.",
   "keywords": [
     "cqrs",


### PR DESCRIPTION
This pull-request classifies this bundle as "symfony-bundle", which is necessary so symfony-flex can make use of auto-configuration.

Example from another bundle:
https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/composer.json

see on the right side, describing the package
https://packagist.org/packages/friendsofsymfony/rest-bundle
