### PR TITLE
Symfony flex compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
 
 matrix:
     include:
-        - php: 5.5
         - php: 5.6
           env: COMPOSER_LOWEST=""
         - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
           env: COMPOSER_LOWEST="--prefer-lowest"
         - php: 7
         - php: hhvm
+        - php: 7.1
     fast_finish: true
     allow_failures:
         - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "php": ">=5.5.9",
     "broadway/broadway": "^1.0",
     "doctrine/doctrine-bundle": "^1.0",
-    "symfony/console": "^2.3|^3.0",
-    "symfony/http-kernel": "^2.3|^3.0"
+    "symfony/console": "^2.3|^3.0|^4.0",
+    "symfony/http-kernel": "^2.3|^3.0|^4.0"
   },
   "authors": [
     {
@@ -47,7 +47,7 @@
     "doctrine/doctrine-bundle": "^1.0",
     "monolog/monolog": "~1.8",
     "symfony/proxy-manager-bridge": "~2.4",
-    "phpunit/phpunit": "^4.8",
+    "phpunit/phpunit": "^5.0",
     "matthiasnoback/symfony-config-test": "^2.0",
     "matthiasnoback/symfony-dependency-injection-test": "^1.1",
     "broadway/broadway-saga": "^0.2"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=5.5.9",
+    "php": ">=5.6",
     "broadway/broadway": "^1.0",
     "doctrine/doctrine-bundle": "^1.0",
     "symfony/console": "^2.3|^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "php": ">=5.6",
     "broadway/broadway": "^1.0",
     "doctrine/doctrine-bundle": "^1.0",
-    "symfony/console": "^2.3|^3.0|^4.0",
-    "symfony/http-kernel": "^2.3|^3.0|^4.0"
+    "symfony/console": "^2.7|^3.3|^4.0",
+    "symfony/http-kernel": "^2.7|^3.3|^4.0"
   },
   "authors": [
     {


### PR DESCRIPTION
I was trying to use the bundle with Symfony flex but installation fails.

As php >= 7.0 is required to run new upcoming Symfony versions there no need to maintain olders in the master branch.  