### PR TITLE
 saga should not be enabled by default

### DIFF
--- a/src/DependencyInjection/BroadwayExtension.php
+++ b/src/DependencyInjection/BroadwayExtension.php
@@ -38,7 +38,7 @@ class BroadwayExtension extends ConfigurableExtension
         $this->loadCommandBus($mergedConfig['command_handling'], $container, $loader);
         $this->loadSerializers($mergedConfig['serializer'], $container, $loader);
 
-        if (isset($mergedConfig['saga'])) {
+        if (isset($mergedConfig['saga']) && isset($mergedConfig['saga']['enabled']) && $mergedConfig['saga']['enabled']) {
             $loader->load('saga.xml');
 
             if (isset($mergedConfig['saga']['state_repository'])) {

--- a/src/DependencyInjection/RegisterSagaStateRepositoryCompilerPass.php
+++ b/src/DependencyInjection/RegisterSagaStateRepositoryCompilerPass.php
@@ -18,6 +18,10 @@ class RegisterSagaStateRepositoryCompilerPass extends CompilerPass
 {
     public function process(ContainerBuilder $container)
     {
+        if (! $container->hasDefinition('broadway.saga.state.in_memory_repository')) {
+            return;
+        }
+
         $serviceParameter = 'broadway.saga.state.repository.service_id';
         if (! $container->hasParameter($serviceParameter)) {
             $container->setAlias(

--- a/test/DependencyInjection/CompilerPass/RegisterSagaStateRepositoryCompilerPassTest.php
+++ b/test/DependencyInjection/CompilerPass/RegisterSagaStateRepositoryCompilerPassTest.php
@@ -11,7 +11,6 @@
 
 namespace Broadway\Bundle\BroadwayBundle\DependencyInjection;
 
-use Broadway\EventStore\EventStore;
 use Broadway\Saga\State\RepositoryInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,6 +23,8 @@ class RegisterSagaStateRepositoryCompilerPassTest extends AbstractCompilerPassTe
      */
     protected function registerCompilerPass(ContainerBuilder $container)
     {
+        $this->setDefinition('broadway.saga.state.in_memory_repository', new Definition(RepositoryInterface::class));
+
         $container->addCompilerPass(new RegisterSagaStateRepositoryCompilerPass());
     }
 

--- a/test/DependencyInjection/Extension/SagaExtensionTest.php
+++ b/test/DependencyInjection/Extension/SagaExtensionTest.php
@@ -26,6 +26,15 @@ class SagaExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_register_the_saga_state_manager_service_when_not_configured()
+    {
+        $this->load([]);
+
+        $this->assertFalse($this->container->hasDefinition('broadway.saga.state.state_manager'));
+    }
 
     /**
      * @test


### PR DESCRIPTION
Apparently saga functionality was enabled even when not configured. This results in a `Error: Class 'Broadway\Saga\SagaMetadataEnricher' not found` when broadway/broadway-saga is not installed.