### PR TITLE
Fix deprecation for symfony/config 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,8 +24,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('broadway');
+        $treeBuilder = new TreeBuilder('broadway');
+
+        if (\method_exists($treeBuilder, 'getRootNode')){
+            $rootNode = $treeBuilder->getRootNode();
+        }
+        else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('broadway');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix: Deprecation: A tree builder without a root node is deprecated since symfony 4.2